### PR TITLE
[WIP] HD-118790 [H] > Videos not embeddable keeps trying to reload and errors on console

### DIFF
--- a/src/components/YouTube.vue
+++ b/src/components/YouTube.vue
@@ -148,6 +148,7 @@ watch(() => props.src, () => {
     }
 
     if (initiated.value
+        && ready.value
         && Boolean(player.value)
         && props.src
     ) {

--- a/src/components/YouTube.vue
+++ b/src/components/YouTube.vue
@@ -143,9 +143,13 @@ watch(() => props.height, () => {
 });
 
 watch(() => props.src, () => {
+    if (!initiated.value) {
+        initPlayer(<HTMLElement>youtube.value);
+    }
+
     if (initiated.value
         && Boolean(player.value)
-        && Boolean(props.src)
+        && props.src
     ) {
         player.value?.loadVideoById(props.src, props.vars?.start ?? 0);
     }


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [HD-118790](https://freedom.myjetbrains.com/youtrack/issue/HD-118790) [H] > Videos not embeddable keeps trying to reload and errors on console

## Summary of requirements
Fix issues when using non-embeddable video

## Summary of changes
Initialize player when src is not empty.

## Checklist
<!--
     Mark the things that have been followed.
-->
- [x] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

# Testing
Test with https://github.com/anyTV/moments-extension/pull/1215